### PR TITLE
Remove malloc.h include

### DIFF
--- a/mpi/mdl.c
+++ b/mpi/mdl.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
-#include <malloc.h>
+//#include <malloc.h>
 #include <math.h>
 #include <limits.h>
 #include <assert.h>

--- a/mpi/mdl.c
+++ b/mpi/mdl.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
-//#include <malloc.h>
 #include <math.h>
 #include <limits.h>
 #include <assert.h>

--- a/null/mdl.c
+++ b/null/mdl.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
-#include <malloc.h>
 #include <math.h>
 #include <limits.h>
 #include <assert.h>


### PR DESCRIPTION
It is deprecated and no longer available on (e.g.) macOS, trying to include it prevents the code from compiling.