### PR TITLE
Remove unused 'atid' pointer from 'null' mdl

### DIFF
--- a/null/mdl.c
+++ b/null/mdl.c
@@ -235,7 +235,6 @@ void mdlFinish(MDL mdl)
 	free(mdl->pszIn);
 	free(mdl->pszOut);
 	free(mdl->cache);
-	free(mdl->atid);
 	free(mdl);
 	}
 

--- a/null/mdl.h
+++ b/null/mdl.h
@@ -50,7 +50,6 @@ typedef struct mdlContext {
 	int nThreads;
 	int idSelf;
 	int bDiag;
-	int *atid;
 	FILE *fpDiag;
 	/*
 	 ** Services stuff!


### PR DESCRIPTION
It would occasionally crash my code during cleanup, and is completely unused in the 'null' version of mdl.